### PR TITLE
Fix SwiftData migration crash on app launch

### DIFF
--- a/Multiplatform/Models/CustomDrink.swift
+++ b/Multiplatform/Models/CustomDrink.swift
@@ -9,7 +9,20 @@ import Foundation
 import SwiftData
 
 // MARK: - Current Model Typealias
-typealias CustomDrink = AppSchemaV2.CustomDrink
+typealias CustomDrink = AppSchemaV3.CustomDrink
+
+extension AppSchemaV3 {
+    @Model
+    final class CustomDrink {
+        var name: String = ""
+        var standardDrinks: Double = 0.0
+        
+        init(name: String, standardDrinks: Double) {
+            self.name = name
+            self.standardDrinks = standardDrinks
+        }
+    }
+}
 
 extension AppSchemaV2 {
     @Model

--- a/Multiplatform/Models/DrinkRecord.swift
+++ b/Multiplatform/Models/DrinkRecord.swift
@@ -9,7 +9,42 @@ import Foundation
 import SwiftData
 
 // MARK: - Current Model Typealias
-typealias DrinkRecord = AppSchemaV2.DrinkRecord
+typealias DrinkRecord = AppSchemaV3.DrinkRecord
+
+extension AppSchemaV3 {
+    @Model
+    final class DrinkRecord: Identifiable {
+        var id = UUID().uuidString
+        var standardDrinks: Double = 0.0
+        var timestamp = Date()
+        
+        init(standardDrinks: Double, date: Date = Date()) {
+            self.standardDrinks = standardDrinks
+            self.timestamp = date
+        }
+        
+        init(_ customDrink: CustomDrink) {
+            self.standardDrinks = customDrink.standardDrinks
+        }
+        
+        static func thisWeeksDrinksPredicate() -> Predicate<DrinkRecord> {
+            let startOfCurrentWeek = Date.startOfWeek
+            
+            return #Predicate<DrinkRecord> { drinkRecord in
+                drinkRecord.timestamp >= startOfCurrentWeek
+            }
+        }
+        
+        static func todaysDrinksPredicate() -> Predicate<DrinkRecord> {
+            let calendar = Calendar.current
+            let startOfToday = calendar.startOfDay(for: Date())
+            let tomorrow = Date.tomorrow
+            return #Predicate<DrinkRecord> { drinkRecord in
+                drinkRecord.timestamp < tomorrow && drinkRecord.timestamp >= startOfToday
+            }
+        }
+    }
+}
 
 extension AppSchemaV2 {
     @Model


### PR DESCRIPTION
## Summary
Fixes critical crash on app launch caused by missing AppSchemaV3 model definitions in SwiftData migration.

• **Root Cause**: AppSchemaV3 referenced `DrinkRecord.self` and `CustomDrink.self` but these model classes didn't exist in the V3 schema extensions
• **Solution**: Added complete model definitions for all schema versions
• **Impact**: App now launches successfully with proper V2→V3 migration

## Problem
The savings tracker PR (#9) introduced AppSchemaV3 but was missing the required model definitions:
- ❌ Missing `AppSchemaV3.DrinkRecord` extension
- ❌ Missing `AppSchemaV3.CustomDrink` extension  
- ❌ Typealiases still pointing to V2 models

When SwiftData tried to initialize the ModelContainer, it couldn't find the referenced models for V3, causing an immediate crash.

## Solution
- ✅ Added `AppSchemaV3.DrinkRecord` extension with complete model definition
- ✅ Added `AppSchemaV3.CustomDrink` extension with complete model definition
- ✅ Updated typealiases to point to V3: `typealias DrinkRecord = AppSchemaV3.DrinkRecord`
- ✅ Updated typealiases to point to V3: `typealias CustomDrink = AppSchemaV3.CustomDrink`

## Testing
- [x] App builds successfully
- [x] App launches without crash
- [x] Unit tests pass including SavingsCalculatorTests
- [x] Migration works properly from existing V2 data
- [x] No data loss during migration

## Files Changed
- `Multiplatform/Models/DrinkRecord.swift`
- `Multiplatform/Models/CustomDrink.swift`

🤖 Generated with [Claude Code](https://claude.ai/code)