### PR TITLE
Simplify brain facts display and fix randomization

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,8 @@
       "Bash(git commit:*)",
       "Bash(git add:*)",
       "Bash(ls:*)",
-      "WebFetch(domain:www.hackingwithswift.com)"
+      "WebFetch(domain:www.hackingwithswift.com)",
+      "Bash(echo:*)"
     ],
     "deny": []
   }

--- a/Multiplatform/MainScreen/BrainHealingTimelineScreen.swift
+++ b/Multiplatform/MainScreen/BrainHealingTimelineScreen.swift
@@ -170,7 +170,7 @@ struct TimelineStageView: View {
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.leading)
                 } else if !isCurrentStage {
-                    Text("Key benefits include improved mood, better sleep, enhanced memory, and increased cognitive function.")
+                    Text(stage.summary)
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.leading)

--- a/Multiplatform/MainScreen/MainScreen.swift
+++ b/Multiplatform/MainScreen/MainScreen.swift
@@ -24,6 +24,7 @@ struct MainScreen: View {
     ) private var allDrinks: [DrinkRecord]
     
     @State private var currentStreak: Int = 0
+    @State private var factRandomizationTrigger: Int = 0
     
     private var dailyLimit: Double? {
         settingsStore.dailyLimit > 0 ? settingsStore.dailyLimit : nil
@@ -148,7 +149,8 @@ struct MainScreen: View {
                     longestStreak: longestStreak,
                     showSavings: settingsStore.showSavings,
                     monthlyAlcoholSpend: settingsStore.monthlyAlcoholSpend,
-                    healingMomentumDays: healingMomentumDays
+                    healingMomentumDays: healingMomentumDays,
+                    randomizationTrigger: factRandomizationTrigger
                 )
                 
                 if dailyLimit != nil || weeklyLimit != nil {
@@ -218,6 +220,7 @@ struct MainScreen: View {
             _ = allDrinks
             currentStreak = businessLogic.refreshCurrentStreak(from: allDrinks, settingsStore: settingsStore)
             settingsStore.updateHealingMomentum(with: allDrinks)  // Always update on foreground
+            factRandomizationTrigger += 1  // Trigger brain fact randomization
         }
     }
     

--- a/Multiplatform/Models/BrainHealingStage.swift
+++ b/Multiplatform/Models/BrainHealingStage.swift
@@ -12,6 +12,7 @@ struct BrainHealingStage {
     let maxDays: Int?
     let title: String
     let facts: [String]
+    let summary: String
     
     static func stage(for days: Double) -> BrainHealingStage {
         let dayCount = Int(days)
@@ -29,7 +30,8 @@ struct BrainHealingStage {
                 "Your brain is already working to rebalance important neurotransmitters that help regulate mood and sleep. This process begins within hours of your last drink.",
                 "You may notice your sleep patterns starting to improve. While it might take some time to feel fully rested, your brain is learning to sleep naturally again.",
                 "Any anxiety or irritability you're experiencing should begin to lessen as your nervous system adjusts to functioning without alcohol."
-            ]
+            ],
+            summary: "Your brain begins rebalancing neurotransmitters for better mood and sleep regulation within hours."
         ),
         BrainHealingStage(
             minDays: 7,
@@ -39,7 +41,8 @@ struct BrainHealingStage {
                 "Your short-term memory is likely improving, making it easier to remember conversations, where you put things, and daily tasks.",
                 "You may notice better coordination and balance as your cerebellum recovers. Simple activities like walking and fine motor skills are becoming more precise.",
                 "Brain cells that had shrunk due to alcohol use are returning to their normal size, essentially allowing your brain to function more efficiently."
-            ]
+            ],
+            summary: "Memory and coordination improve as brain cells return to normal size and function more efficiently."
         ),
         BrainHealingStage(
             minDays: 30,
@@ -49,7 +52,8 @@ struct BrainHealingStage {
                 "Your brain is forming new neural connections at an accelerated rate. This neuroplasticity is helping you develop healthier thinking patterns and habits.",
                 "Mood stability is typically much improved by now. The emotional ups and downs that alcohol can cause are giving way to more consistent, natural feelings.",
                 "You'll likely notice better concentration and higher energy levels. Mental tasks that felt difficult before may now feel more manageable."
-            ]
+            ],
+            summary: "New neural connections form rapidly, improving mood stability, concentration, and energy levels."
         ),
         BrainHealingStage(
             minDays: 90,
@@ -59,7 +63,8 @@ struct BrainHealingStage {
                 "Long-term memory function continues to improve, making it easier to recall past experiences and learn new information effectively.",
                 "Problem-solving abilities and critical thinking skills are enhanced as the brain regions responsible for executive function heal and strengthen.",
                 "Brain imaging would show increased brain volume during this period. Your brain is literally growing healthier and more resilient."
-            ]
+            ],
+            summary: "Long-term memory and problem-solving abilities strengthen as brain volume increases."
         ),
         BrainHealingStage(
             minDays: 180,
@@ -69,7 +74,8 @@ struct BrainHealingStage {
                 "Emotional regulation has likely improved significantly. You're probably better at managing stress and recovering from difficult situations.",
                 "Sleep quality at this stage is typically much better than before. Quality rest is now supporting all other aspects of your health and recovery.",
                 "Many people find their cognitive abilities are now equal to or better than they were before alcohol became a concern. Your brain has become more efficient."
-            ]
+            ],
+            summary: "Emotional regulation and sleep quality reach new heights as cognitive abilities become more efficient."
         ),
         BrainHealingStage(
             minDays: 365,
@@ -79,7 +85,8 @@ struct BrainHealingStage {
                 "Your brain is now creating new brain cells through neurogenesis. This process helps maintain cognitive function and emotional resilience.",
                 "Brain plasticity continues to improve, meaning your ability to learn, adapt, and form new memories keeps getting better with time.",
                 "Research shows brain healing can continue for many years. Each day of sobriety is an investment in your long-term cognitive health and wellbeing."
-            ]
+            ],
+            summary: "New brain cells form through neurogenesis while plasticity continues improving learning and adaptation."
         )
     ]
 }


### PR DESCRIPTION
## Summary
- Remove scrolling and chevron buttons from brain facts display
- Replace with single, randomly chosen fact that changes on each app launch/restore
- Make fact tappable to open brain healing timeline
- Improve timeline display to show consistent facts for inactive stages

## Changes Made
- **Simplified UI**: Removed complex TabView scrolling and navigation buttons
- **Random fact selection**: Facts now randomize when app appears or is restored from background  
- **Tappable interaction**: Single tap on fact opens the full healing timeline
- **Bug fix**: Timeline now shows appropriate content for all healing stages
- **Code cleanup**: Eliminated 80+ lines of complex state management and wrap-around logic

## Test Plan
- [x] Build successfully compiles
- [x] Brain facts display single random fact
- [x] Fact changes when app is restored from background
- [x] Tapping fact opens healing timeline
- [x] Timeline displays correctly for all stages
- [x] Accessibility labels and hints work properly

🤖 Generated with [Claude Code](https://claude.ai/code)