### PR TITLE
Fix drinking status calculation to use calendar days instead of exact timestamps

### DIFF
--- a/Multiplatform/Utilities/DrinkingStatusCalculator.swift
+++ b/Multiplatform/Utilities/DrinkingStatusCalculator.swift
@@ -23,8 +23,8 @@ struct DrinkingStatusCalculator {
         let periodStartDate = Calendar.current.date(
             byAdding: .day, 
             value: -period.days, 
-            to: Date()
-        ) ?? Date()
+            to: Calendar.current.startOfDay(for: Date())
+        ) ?? Calendar.current.startOfDay(for: Date())
         
         Logger.drinkingStatus.info("📅 Date calculations: trackingStart=\(trackingStartDate), periodStart=\(periodStartDate)")
         
@@ -73,8 +73,8 @@ struct DrinkingStatusCalculator {
         let periodStartDate = Calendar.current.date(
             byAdding: .day, 
             value: -period.days, 
-            to: Date()
-        ) ?? Date()
+            to: Calendar.current.startOfDay(for: Date())
+        ) ?? Calendar.current.startOfDay(for: Date())
         
         let effectiveStartDate = max(trackingStartDate, periodStartDate)
         


### PR DESCRIPTION
## Summary
• Fixed drinking status intervals (7 days, 30 days, year) that were recalculating throughout the day based on exact timestamps
• Changed calculation to use `Calendar.current.startOfDay(for: Date())` instead of `Date()` for consistent day-based periods
• Ensures drinking status only changes when crossing into a new calendar day, not at random times during the day

## Test plan
- [x] Build project successfully
- [x] Verify drinking status calculation uses start of day for period boundaries
- [x] Confirm status remains consistent throughout the day
- [x] Test that calculations still work correctly for all periods (7 days, 30 days, year)

🤖 Generated with [Claude Code](https://claude.ai/code)