### PR TITLE
Show weekly averages for light drinkers on dashboard

### DIFF
--- a/Multiplatform/MainScreen/DashboardCardView.swift
+++ b/Multiplatform/MainScreen/DashboardCardView.swift
@@ -19,29 +19,53 @@ struct DashboardCardView: View {
     
     private var average7Days: Double? {
         guard settingsStore.drinkingStatusTrackingEnabled else { return nil }
-        return DrinkingStatusCalculator.calculateAverageDrinksPerDay(
-            for: .week7,
-            drinks: drinkRecords,
-            trackingStartDate: settingsStore.drinkingStatusStartDate
-        )
+        if drinkingStatus7Days == .lightDrinker {
+            return DrinkingStatusCalculator.calculateAverageDrinksPerWeek(
+                for: .week7,
+                drinks: drinkRecords,
+                trackingStartDate: settingsStore.drinkingStatusStartDate
+            )
+        } else {
+            return DrinkingStatusCalculator.calculateAverageDrinksPerDay(
+                for: .week7,
+                drinks: drinkRecords,
+                trackingStartDate: settingsStore.drinkingStatusStartDate
+            )
+        }
     }
     
     private var average30Days: Double? {
         guard settingsStore.drinkingStatusTrackingEnabled else { return nil }
-        return DrinkingStatusCalculator.calculateAverageDrinksPerDay(
-            for: .days30,
-            drinks: drinkRecords,
-            trackingStartDate: settingsStore.drinkingStatusStartDate
-        )
+        if drinkingStatus30Days == .lightDrinker {
+            return DrinkingStatusCalculator.calculateAverageDrinksPerWeek(
+                for: .days30,
+                drinks: drinkRecords,
+                trackingStartDate: settingsStore.drinkingStatusStartDate
+            )
+        } else {
+            return DrinkingStatusCalculator.calculateAverageDrinksPerDay(
+                for: .days30,
+                drinks: drinkRecords,
+                trackingStartDate: settingsStore.drinkingStatusStartDate
+            )
+        }
     }
     
     private var averageYear: Double? {
         guard settingsStore.drinkingStatusTrackingEnabled else { return nil }
-        return DrinkingStatusCalculator.calculateAverageDrinksPerDay(
-            for: .year,
-            drinks: drinkRecords,
-            trackingStartDate: settingsStore.drinkingStatusStartDate
-        )
+        if drinkingStatusYear == .lightDrinker {
+            return DrinkingStatusCalculator.calculateAverageDrinksPerWeek(
+                for: .year,
+                drinks: drinkRecords,
+                trackingStartDate: settingsStore.drinkingStatusStartDate
+            )
+        } else {
+            return DrinkingStatusCalculator.calculateAverageDrinksPerDay(
+                for: .year,
+                drinks: drinkRecords,
+                trackingStartDate: settingsStore.drinkingStatusStartDate
+            )
+        }
     }
     
     var body: some View {
@@ -75,7 +99,8 @@ struct DashboardCardView: View {
                         .font(.subheadline)
                         .foregroundStyle(Color.secondary)
                     if let average = average7Days {
-                        Text("\(Formatter.formatDecimal(average)) per day")
+                        let unit = drinkingStatus7Days == .lightDrinker ? "per week" : "per day"
+                        Text("\(Formatter.formatDecimal(average)) \(unit)")
                             .font(.subheadline)
                             .foregroundStyle(Color.secondary)
                     }
@@ -96,7 +121,8 @@ struct DashboardCardView: View {
                         .font(.subheadline)
                         .foregroundStyle(Color.secondary)
                     if let average = average30Days {
-                        Text("\(Formatter.formatDecimal(average)) per day")
+                        let unit = drinkingStatus30Days == .lightDrinker ? "per week" : "per day"
+                        Text("\(Formatter.formatDecimal(average)) \(unit)")
                             .font(.subheadline)
                             .foregroundStyle(Color.secondary)
                     }
@@ -117,7 +143,8 @@ struct DashboardCardView: View {
                         .font(.subheadline)
                         .foregroundStyle(Color.secondary)
                     if let average = averageYear {
-                        Text("\(Formatter.formatDecimal(average)) per day")
+                        let unit = drinkingStatusYear == .lightDrinker ? "per week" : "per day"
+                        Text("\(Formatter.formatDecimal(average)) \(unit)")
                             .font(.subheadline)
                             .foregroundStyle(Color.secondary)
                     }
@@ -180,21 +207,24 @@ struct DashboardCardView: View {
         if let status7 = drinkingStatus7Days {
             label += "Last 7 days \(status7.rawValue)"
             if let avg = average7Days {
-                label += ", \(Formatter.formatDecimal(avg)) drinks per day"
+                let unit = status7 == .lightDrinker ? "per week" : "per day"
+                label += ", \(Formatter.formatDecimal(avg)) drinks \(unit)"
             }
             label += ", "
         }
         if let status30 = drinkingStatus30Days {
             label += "Last 30 days \(status30.rawValue)"
             if let avg = average30Days {
-                label += ", \(Formatter.formatDecimal(avg)) drinks per day"
+                let unit = status30 == .lightDrinker ? "per week" : "per day"
+                label += ", \(Formatter.formatDecimal(avg)) drinks \(unit)"
             }
             label += ", "
         }
         if let statusYear = drinkingStatusYear {
             label += "Last year \(statusYear.rawValue)"
             if let avg = averageYear {
-                label += ", \(Formatter.formatDecimal(avg)) drinks per day"
+                let unit = statusYear == .lightDrinker ? "per week" : "per day"
+                label += ", \(Formatter.formatDecimal(avg)) drinks \(unit)"
             }
             label += ". "
         }

--- a/Multiplatform/Utilities/DrinkingStatusCalculator.swift
+++ b/Multiplatform/Utilities/DrinkingStatusCalculator.swift
@@ -97,6 +97,40 @@ struct DrinkingStatusCalculator {
         return totalDrinks / Double(period.days)
     }
     
+    static func calculateAverageDrinksPerWeek(
+        for period: ReportingPeriod,
+        drinks: [DrinkRecord], 
+        trackingStartDate: Date
+    ) -> Double? {
+        let trackingStartDate = trackingStartDate
+        let periodStartDate = Calendar.current.date(
+            byAdding: .day, 
+            value: -period.days, 
+            to: Calendar.current.startOfDay(for: Date())
+        ) ?? Calendar.current.startOfDay(for: Date())
+        
+        let effectiveStartDate = max(trackingStartDate, periodStartDate)
+        
+        // Check if we have enough tracking data
+        let daysSinceTracking = Calendar.current.dateComponents(
+            [.day], 
+            from: trackingStartDate, 
+            to: Date()
+        ).day ?? 0
+        
+        guard daysSinceTracking >= period.days else { return nil }
+        
+        let relevantDrinks = drinks.filter { drink in
+            drink.timestamp >= effectiveStartDate
+        }
+        
+        let totalDrinks = relevantDrinks.reduce(0) { $0 + $1.standardDrinks }
+        let weeksInPeriod = Double(period.days) / 7.0
+        
+        // Calculate average drinks per week for the period
+        return totalDrinks / weeksInPeriod
+    }
+    
     private static func classifyDrinkingStatus(drinksPerWeek: Double, sex: Sex) -> DrinkingStatus {
         Logger.drinkingStatus.info("🔍 Classifying: drinksPerWeek=\(drinksPerWeek), sex=\(sex.rawValue)")
         


### PR DESCRIPTION
## Summary
- Light drinkers now see drinks "per week" instead of "per day" on the dashboard
- Moderate and heavy drinkers continue to see "per day" as before
- Updated all three time periods (7 days, 30 days, 1 year) to use appropriate units
- Improved accessibility with correct VoiceOver labels

## Changes Made
- Added `calculateAverageDrinksPerWeek()` method to `DrinkingStatusCalculator`
- Updated dashboard computed properties to conditionally use weekly vs daily calculations
- Modified display text to show appropriate units based on drinking status
- Updated accessibility labels to announce correct units for VoiceOver users

## Why This Change?
Previously, light drinkers (0.1-3.0 drinks per week) would see very small decimal numbers like "0.14 per day" which was less meaningful. Now they see more intuitive values like "1.0 per week" while heavier drinkers continue to see daily averages that make sense for their consumption patterns.

## Test Plan
- [x] Code compiles successfully
- [x] Dashboard displays correct units based on drinking status
- [x] Light drinkers see "per week", others see "per day"
- [x] Accessibility labels correctly announce units
- [x] All three time periods work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)