### PR TITLE
Add iOS CI workflow with GitHub Actions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,32 @@
+name: iOS CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    runs-on: macos-15
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Select Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_26.0.1.app
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Build and Test
+      run: |
+        set -o pipefail
+        xcodebuild test \
+          -project DrinkTracker.xcodeproj \
+          -scheme "DrinkTracker Dev" \
+          -destination "platform=iOS Simulator,name=iPhone 17,OS=26.0" \
+          -only-testing:DrinkTrackerTests \
+          ENABLE_SWIFT_TESTING=YES \
+          | xcpretty && exit ${PIPESTATUS[0]}

--- a/DrinkTracker.xcodeproj/xcshareddata/xcschemes/DrinkTracker Dev.xcscheme
+++ b/DrinkTracker.xcodeproj/xcshareddata/xcschemes/DrinkTracker Dev.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CE4169902BD97FB10028D64A"
+               BuildableName = "DrinkTracker.app"
+               BlueprintName = "DrinkTracker"
+               ReferencedContainer = "container:DrinkTracker.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:DrinkTrackerTests/DrinkTracker Dev.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CE4169A22BD97FB30028D64A"
+               BuildableName = "DrinkTrackerTests.xctest"
+               BlueprintName = "DrinkTrackerTests"
+               ReferencedContainer = "container:DrinkTracker.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CE4169902BD97FB10028D64A"
+            BuildableName = "DrinkTracker.app"
+            BlueprintName = "DrinkTracker"
+            ReferencedContainer = "container:DrinkTracker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CE4169902BD97FB10028D64A"
+            BuildableName = "DrinkTracker.app"
+            BlueprintName = "DrinkTracker"
+            ReferencedContainer = "container:DrinkTracker.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'xcpretty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rouge (3.28.0)
+    xcpretty (0.4.1)
+      rouge (~> 3.28.0)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  xcpretty
+
+BUNDLED WITH
+   2.2.3


### PR DESCRIPTION
## Summary

Implements GitHub Actions CI workflow as specified in issue #23:
- Runs on all PRs and pushes to main branch
- Uses macOS 15 runner with Xcode 26.0.1 and iOS 26.0 simulator
- Executes full test suite with Swift Testing enabled
- Formats output with xcpretty for better readability

## Changes

- Added `.github/workflows/ios.yml` - CI workflow configuration
- Added `Gemfile` and `Gemfile.lock` - xcpretty for formatted test output
- Shared `DrinkTracker Dev` scheme in Xcode project for CI access

## Test Plan

- [x] Tests pass locally with the exact command used in CI
- [ ] Verify CI workflow runs successfully on this PR
- [ ] Confirm green checkmark appears on commits

## Related

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)