### PR TITLE
Fix dashboard bugs in moderation mode

### DIFF
--- a/Multiplatform/MainScreen/DashboardCardView.swift
+++ b/Multiplatform/MainScreen/DashboardCardView.swift
@@ -68,7 +68,11 @@ struct DashboardCardView: View {
             )
         }
     }
-    
+
+    private var totalDrinksToday: Double {
+        drinkRecords.todaysRecords.totalStandardDrinks
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             if goal == .abstinence {
@@ -82,6 +86,22 @@ struct DashboardCardView: View {
                 }
 
                 Text(Formatter.formatStreakDuration(currentStreak))
+                    .font(.title)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.primary)
+            }
+
+            if goal == .moderation {
+                HStack {
+                    Image(systemName: "drop.fill")
+                        .foregroundStyle(Color.primaryAction)
+                        .accessibilityHidden(true)
+                    Text("Today's Drinks")
+                        .font(.headline)
+                        .foregroundStyle(Color.primary)
+                }
+
+                Text(Formatter.formatDecimal(totalDrinksToday))
                     .font(.title)
                     .fontWeight(.semibold)
                     .foregroundStyle(.primary)
@@ -210,6 +230,8 @@ struct DashboardCardView: View {
 
         if goal == .abstinence {
             label += "Current streak: \(Formatter.formatStreakDuration(currentStreak)). "
+        } else if goal == .moderation {
+            label += "Today's drinks: \(Formatter.formatDecimal(totalDrinksToday)). "
         }
 
         label += "Drinking status: "

--- a/Multiplatform/MainScreen/MainScreen.swift
+++ b/Multiplatform/MainScreen/MainScreen.swift
@@ -288,8 +288,10 @@ struct MainScreen: View {
         switch sheet {
         case .quickEntry:
             return AnyView(QuickEntryView { drinkRecord in
-                Task { await businessLogic.recordDrink(drinkRecord) }
-                router.dismiss()
+                Task {
+                    await businessLogic.recordDrink(drinkRecord)
+                    router.dismiss()
+                }
             }
             .presentationDetents([.fraction(0.2)]))
         case .calculator(let createCustomDrink, let createDrinkRecord):

--- a/Multiplatform/MainScreen/MainScreenBusinessLogic.swift
+++ b/Multiplatform/MainScreen/MainScreenBusinessLogic.swift
@@ -78,6 +78,7 @@ class MainScreenBusinessLogic {
         }
         
         modelContext.insert(drink)
+        try? modelContext.save()
         recordingDrinkComplete.toggle()
     }
     


### PR DESCRIPTION
## Summary

Fixes two critical bugs in the moderation mode dashboard (issue #28):

1. **Missing today's drinks display** - Dashboard now prominently shows today's drink count in large format at the top of the card for moderation mode users, matching the visual hierarchy of abstinence mode's streak display.

2. **Dashboard not updating after drink recording** - Dashboard now refreshes immediately after logging a drink instead of requiring an app restart. Fixed by ensuring proper async/await ordering and adding explicit SwiftData context save.

## Changes

### Commit 1: Add today's drinks display for moderation mode
- Added `totalDrinksToday` computed property to DashboardCardView
- Display today's drinks in large format at top of dashboard card
- Updated accessibility label to include today's drinks count for VoiceOver

### Commit 2: Fix dashboard refresh after recording drink  
- Updated QuickEntry completion to use proper async/await ordering (dismiss after record completes)
- Added explicit `modelContext.save()` call in `recordDrink()` method
- Ensures SwiftData @Query detects changes and triggers dashboard refresh

## Test Plan

### Manual Testing
- [x] Build succeeds
- [x] Unit tests pass
- [ ] Verify today's drinks display shows in moderation mode
- [ ] Record drink via QuickEntry and confirm immediate dashboard update
- [ ] Test abstinence mode for regressions
- [ ] Verify accessibility with VoiceOver

### Technical Details
The dashboard refresh issue required two fixes:
1. Async/await ordering: Sheet must dismiss after drink recording completes
2. Explicit save: SwiftData requires `modelContext.save()` for @Query to detect changes

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)