### PR TITLE
Fix haptic feedback when recording drinks

### DIFF
--- a/Multiplatform/DrinkTrackerApp.swift
+++ b/Multiplatform/DrinkTrackerApp.swift
@@ -14,10 +14,11 @@ import OSLog
 @main
 struct DrinkTrackerApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
     @State private var trigger = false
     @State private var settingsStore: SettingsStore?
-    
+    @State private var mainScreenBusinessLogic: MainScreenBusinessLogic?
+
     private let quickActionHandler = QuickActionHandler.shared
     private let appRouter = AppRouter()
     
@@ -40,16 +41,18 @@ struct DrinkTrackerApp: App {
     var body: some Scene {
         WindowGroup {
             Group {
-                if let settingsStore {
+                if let settingsStore, let mainScreenBusinessLogic {
                     MainScreen()
                         .environment(quickActionHandler)
                         .environment(appRouter)
                         .environment(settingsStore)
+                        .environment(mainScreenBusinessLogic)
                 } else {
                     // Loading state while SettingsStore initializes
                     Text("Loading...")
                         .onAppear {
                             initializeSettingsStore()
+                            initializeMainScreenBusinessLogic()
                         }
                 }
             }
@@ -94,5 +97,10 @@ struct DrinkTrackerApp: App {
     private func initializeSettingsStore() {
         let context = sharedModelContainer.mainContext
         settingsStore = SettingsStore(modelContext: context)
+    }
+
+    private func initializeMainScreenBusinessLogic() {
+        let context = sharedModelContainer.mainContext
+        mainScreenBusinessLogic = MainScreenBusinessLogic.create(context: context)
     }
 }

--- a/Multiplatform/MainScreen/MainScreen.swift
+++ b/Multiplatform/MainScreen/MainScreen.swift
@@ -25,25 +25,22 @@ struct MainScreen: View {
     
     @State private var currentStreak: Int = 0
     @State private var factRandomizationTrigger: Int = 0
-    
+    @Environment(MainScreenBusinessLogic.self) private var businessLogic
+
     private var dailyLimit: Double? {
         settingsStore.dailyLimit > 0 ? settingsStore.dailyLimit : nil
     }
-    
+
     private var weeklyLimit: Double? {
         settingsStore.weeklyLimit > 0 ? settingsStore.weeklyLimit : nil
     }
-    
+
     private var longestStreak: Int {
         settingsStore.longestStreak
     }
-    
+
     private var healingMomentumDays: Double {
         settingsStore.healingMomentumDays
-    }
-    
-    private var businessLogic: MainScreenBusinessLogic {
-        MainScreenBusinessLogic.create(context: modelContext)
     }
     
     private var thisWeeksDrinks: [DrinkRecord] {
@@ -250,18 +247,18 @@ struct MainScreen: View {
     
     private func handleOnAppear() {
         currentStreak = businessLogic.refreshCurrentStreak(from: allDrinks, settingsStore: settingsStore)
-        
+
         // Always initialize and update healing momentum
         settingsStore.initializeHealingMomentumIfNeeded(with: allDrinks)
         settingsStore.updateHealingMomentum(with: allDrinks)
-        
+
         router.setQuickActionHandlers(
             addCustomDrink: businessLogic.addCustomDrink,
             recordDrink: { drink in
                 Task { await businessLogic.recordDrink(drink) }
             }
         )
-        
+
         // Initial sync on app launch
         if HKHealthStore.isHealthDataAvailable() {
             Task {


### PR DESCRIPTION
## Summary
Fixes haptic feedback that stopped working when recording drinks by ensuring MainScreenBusinessLogic uses a single persistent instance throughout the view lifecycle.

## Changes
- Initialize MainScreenBusinessLogic at app level (matching SettingsStore pattern)
- Inject via @Environment into MainScreen as non-optional
- Remove all guard statements and optional handling from MainScreen
- Clean up sensoryFeedback trigger to remove optional chaining

## Root Cause
`businessLogic` was previously a computed property that created a new instance on every access. This meant:
- When recording a drink, one instance would toggle `recordingDrinkComplete`
- The sensoryFeedback modifier observed a different instance
- SwiftUI never detected the state change, so haptic feedback never fired

## Solution
By initializing at app level and injecting via @Environment:
- Single persistent instance throughout app lifetime
- SwiftUI properly observes state changes
- Haptic feedback triggers correctly when drinks are recorded

## Test Plan
- [x] Build succeeds
- [x] Unit tests pass
- [ ] Manual test: Record drink via Quick Entry - verify haptic fires
- [ ] Manual test: Record drink via Calculator - verify haptic fires
- [ ] Manual test: Record drink via Custom Drinks - verify haptic fires

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)