### PR TITLE
Fix dark text appearing in dark mode (Issue #37)

### DIFF
--- a/Multiplatform/CustomDrinkScreen.swift
+++ b/Multiplatform/CustomDrinkScreen.swift
@@ -43,7 +43,7 @@ struct CustomDrinkScreen: View {
                             Spacer()
                             Text(Formatter.formatDecimal(drink.standardDrinks))
                         }
-                        .foregroundStyle(Color.black)
+                        .foregroundStyle(.primary)
                     }
                 }
                 .onDelete { offsets in

--- a/Multiplatform/RecordDrinks/CustomDrinkScreen.swift
+++ b/Multiplatform/RecordDrinks/CustomDrinkScreen.swift
@@ -43,7 +43,7 @@ struct CustomDrinkScreen: View {
                             Spacer()
                             Text(Formatter.formatDecimal(drink.standardDrinks))
                         }
-                        .foregroundStyle(Color.black)
+                        .foregroundStyle(.primary)
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Custom drink: \(drink.name)")

--- a/Multiplatform/RecordDrinks/QuickEntryView.swift
+++ b/Multiplatform/RecordDrinks/QuickEntryView.swift
@@ -39,7 +39,7 @@ struct QuickEntryView: View {
                     Text("\(Formatter.formatDecimal(drinkCount))")
                         .font(.largeTitle)
                         .frame(width: 75)
-                        .foregroundStyle(Color.black)
+                        .foregroundStyle(.primary)
                 }
                 .buttonStyle(PlainButtonStyle())
                 .accessibilityLabel("Current drink count")


### PR DESCRIPTION
## Summary
Fixed dark text that appears invisible in dark mode by replacing hardcoded `Color.black` with `.primary` for adaptive color styling.

## Changes
- **QuickEntryView.swift**: Updated drink count text color to use `.primary`
- **CustomDrinkScreen.swift (RecordDrinks)**: Updated custom drink cell text to use `.primary`
- **CustomDrinkScreen.swift (Multiplatform)**: Updated custom drink cell text to use `.primary`

## How it works
- `.primary` is SwiftUI's adaptive system color that automatically switches between black (light mode) and white (dark mode)
- Text now remains visible and readable in both light and dark modes
- Maintains WCAG 2.1 AA compliance

## Test plan
- [x] Build successful with xcodebuild
- [x] All unit tests pass
- [x] Verified in both light and dark mode appearance settings

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)